### PR TITLE
Issue 344 & 346 (Overloard not drawing cards into hand & Young Witch choosing Landmarks as bane pile)

### DIFF
--- a/vdom/src/com/vdom/core/CardSet.java
+++ b/vdom/src/com/vdom/core/CardSet.java
@@ -302,7 +302,7 @@ public class CardSet {
 		
 		swapFrom.remove(bane);
 		for (Card c : replaceFrom) {
-			if (!c.equals(bane) && !swapFrom.contains(c)) {
+			if (!c.equals(bane) && !swapFrom.contains(c) && !c.is(Type.Event) && !c.is(Type.Landmark)) {
 				swapFrom.add(c);
 				break;
 			}
@@ -312,7 +312,7 @@ public class CardSet {
 	
 	private static boolean isValidBane(Card c) {
 		int cost = c.getCost(null);
-		return !c.costPotion() && (cost == 2 || cost == 3) && !c.is(Type.Event, null);
+		return !c.costPotion() && (cost == 2 || cost == 3) && !c.is(Type.Event, null) && !c.is(Type.Landmark, null);
 	}
 
 	private static void pick(List<Card> source, List<Card> target, int count) {

--- a/vdom/src/com/vdom/core/Game.java
+++ b/vdom/src/com/vdom/core/Game.java
@@ -3087,6 +3087,8 @@ public class Game {
                             if (r.equals(Cards.estate) && player.getInheritance() != null) {
                             	r = player.getInheritance();
                             }
+
+                            r = r.behaveAsCard(); //Get impersonated card
                             
                             if (r.equals(Cards.armory)
                                 || r.equals(Cards.artificer)

--- a/vdom/src/com/vdom/core/Player.java
+++ b/vdom/src/com/vdom/core/Player.java
@@ -791,10 +791,14 @@ public abstract class Player {
         		if (actionCount >= 3) {
         			threePlusCopyActionCards++;
         		}
-        		if (actionCount > highestActionCardCount) {
-        			secondHighestActionCardCount = highestActionCardCount;
-        			highestActionCardCount = actionCount;
-        		}
+			if (actionCount > secondHighestActionCardCount) {
+				if (actionCount > highestActionCardCount) {
+					secondHighestActionCardCount = highestActionCardCount;
+					highestActionCardCount = actionCount;
+				} else {
+					secondHighestActionCardCount = actionCount;
+				}
+			}
         	}
         	if ((!c.is(Type.Victory, this)) && Cards.isSupplyCard(c) && this.game.isPileEmpty(c)) {
         		nonVictoryEmptySupplyPileCards += allCardCounts.get(c);

--- a/vdom/src/com/vdom/core/Player.java
+++ b/vdom/src/com/vdom/core/Player.java
@@ -794,8 +794,7 @@ public abstract class Player {
 			if (actionCount >= highestActionCardCount) {
 				secondHighestActionCardCount = highestActionCardCount;
 				highestActionCardCount = actionCount;
-			}
-			if (actionCount > secondHighestActionCardCount) {
+			} else if (actionCount > secondHighestActionCardCount) {
 				secondHighestActionCardCount = actionCount;
 			}
         	}

--- a/vdom/src/com/vdom/core/Player.java
+++ b/vdom/src/com/vdom/core/Player.java
@@ -791,13 +791,12 @@ public abstract class Player {
         		if (actionCount >= 3) {
         			threePlusCopyActionCards++;
         		}
+			if (actionCount >= highestActionCardCount) {
+				secondHighestActionCardCount = highestActionCardCount;
+				highestActionCardCount = actionCount;
+			}
 			if (actionCount > secondHighestActionCardCount) {
-				if (actionCount > highestActionCardCount) {
-					secondHighestActionCardCount = highestActionCardCount;
-					highestActionCardCount = actionCount;
-				} else {
-					secondHighestActionCardCount = actionCount;
-				}
+				secondHighestActionCardCount = actionCount;
 			}
         	}
         	if ((!c.is(Type.Victory, this)) && Cards.isSupplyCard(c) && this.game.isPileEmpty(c)) {


### PR DESCRIPTION
Reason is that the cards pass their control card as 'responsible' parameter when calling gainNewCard(). In the gameEvent handler the responsible card type is checked (to determine if the gained card should be put in hand or on top of deck) withouth checking whether the card is impersonating another card.

Cards which don't use the controlcard as 'responsible' parameter did correctly topdeck/put in hand (Like Tournament). But maybe this should be changed for consitency, so that all cards always pass themselves or always pass the control card.

(Also I don't know why the Triumphal Arch again shows up in this pull request).