### PR TITLE
Victory tokens details in end game summary. And fixes for #411, #412 and #413

### DIFF
--- a/androminion/res/values-de/strings-preferences.xml
+++ b/androminion/res/values-de/strings-preferences.xml
@@ -63,6 +63,10 @@
     <string name="hide_card_counts_pref_summary">(wirksam mit nächstem Spiel)</string>
     <string name="one_turn_logs_pref_title">Details eines Zuges</string>
     <string name="one_turn_logs_pref_summary">Nur den aktuellen Zug im Spiellog am unteren Ende des Bildschirmes zeigen (wirksam mit nächstem Spiel)</string>
+    <string name="game_over_castle_details_pref_title">Zeige Schlösser Details nach dem Spiel</string>
+    <string name="game_over_castle_details_pref_summary">Zeigt die Punkte der jeweiligen Schlösser an</string>
+    <string name="game_over_vp_token_details_pref_title">Zeige Siegpunktmarker Details nach dem Spiel</string>
+    <string name="game_over_vp_token_details_pref_summary">Zeigt an welche Karten wieviele Siegpunktmarker erworben haben</string>
     <string name="logging_pref_title">Spielaufzeichnung</string>
     <string name="logging_enable_pref_title">Aktiviere Spielaufzeichnung</string>
     <string name="logging_enable_pref_summary">Aufzeichnungen werden als Textdatei auf der SD-Karte gespeichert</string>

--- a/androminion/res/values/strings-preferences.xml
+++ b/androminion/res/values/strings-preferences.xml
@@ -48,6 +48,10 @@
 		    <string name="sort_cards_pref_summary">By type: Action, Treasure, Curse, Victory</string>
 		    <string name="one_turn_logs_pref_title">Current turn log only</string>
 		    <string name="one_turn_logs_pref_summary">Only show the current turn in the game log</string>
+			<string name="game_over_castle_details_pref_title">Display Castle details in game summary</string>
+			<string name="game_over_castle_details_pref_summary">Show amount of VP for each Castle</string>
+			<string name="game_over_vp_token_details_pref_title">Display victory token details in game summary</string>
+			<string name="game_over_vp_token_details_pref_summary">Display which cards added what amount of victory tokens</string>
 	    <string name="vibescreen_pref_title">Vibration</string>
 		    <string name="allvibes_pref_title">Enable</string>
 			<string name="clickvibeon_pref_title">When select card</string>

--- a/androminion/res/xml/preferences.xml
+++ b/androminion/res/xml/preferences.xml
@@ -47,11 +47,29 @@
             android:summary="%s"
             android:title="@string/pref_theme_title" />
         <PreferenceScreen android:title="@string/game_screen_pref_title">
-            <CheckBoxPreference
-	            android:defaultValue="true"
-	            android:key="show_game_log"
-	            android:summary="@string/pref_show_game_log_summary"
-	            android:title="@string/pref_show_game_log_title" />
+			<PreferenceScreen android:title="@string/logging_pref_title">
+				<CheckBoxPreference
+					android:defaultValue="true"
+					android:key="show_game_log"
+					android:summary="@string/pref_show_game_log_summary"
+					android:title="@string/pref_show_game_log_title" />
+				<CheckBoxPreference
+					android:dependency="show_game_log"
+					android:defaultValue="false"
+					android:key="one_turn_logs"
+					android:summary="@string/one_turn_logs_pref_summary"
+					android:title="@string/one_turn_logs_pref_title" />
+				<CheckBoxPreference
+					android:defaultValue="true"
+					android:key="game_over_castle_details"
+					android:summary="@string/game_over_castle_details_pref_summary"
+					android:title="@string/game_over_castle_details_pref_title" />
+				<CheckBoxPreference
+					android:defaultValue="true"
+					android:key="game_over_vp_token_details"
+					android:summary="@string/game_over_vp_token_details_pref_summary"
+					android:title="@string/game_over_vp_token_details_pref_title" />
+			</PreferenceScreen>
 	        <CheckBoxPreference
 	            android:defaultValue="true"
 	            android:key="show_statusbar"
@@ -84,12 +102,6 @@
 		            android:key="sort_cards"
 		            android:summary="@string/sort_cards_pref_summary"
 		            android:title="@string/sort_cards_pref_title" />
-		        <CheckBoxPreference
-		            android:dependency="show_game_log"
-		            android:defaultValue="false"
-		            android:key="one_turn_logs"
-		            android:summary="@string/one_turn_logs_pref_summary"
-		            android:title="@string/one_turn_logs_pref_title" />
 	        </PreferenceCategory>
         </PreferenceScreen>
         <PreferenceScreen android:title="@string/vibescreen_pref_title">

--- a/androminion/src/com/mehtank/androminion/activities/GameActivity.java
+++ b/androminion/src/com/mehtank/androminion/activities/GameActivity.java
@@ -742,7 +742,7 @@ public class GameActivity extends SherlockActivity implements EventHandler {
 
         int i=0;
         for (MyCard c : cards)
-            edit.putString("LastCard" + i++, (c.isBane ? Game.BANE : "") + (c.isBlackMarket ? Game.BLACKMARKET : "") + c.originalSafeName);
+            edit.putString("LastCard" + i++, (c.isBane ? Game.BANE : "") + (c.isObeliskCard ? Game.OBELISK : "") + (c.isBlackMarket ? Game.BLACKMARKET : "") + c.originalSafeName);
 
         edit.commit();
     }

--- a/vdom/src/com/vdom/core/BasePlayer.java
+++ b/vdom/src/com/vdom/core/BasePlayer.java
@@ -3492,7 +3492,7 @@ public abstract class BasePlayer extends Player implements GameEventListener {
     public Card call_whenGainCardToCall(MoveContext context, Card gainedCard, Card[] possibleCards) {
     	// only possible cards to call here are Duplicate or Estate (behaving like a Duplicate)
     	for (Card c : possibleCards) {
-    		if (!(c.equals(Cards.duplicate) || c.equals(Cards.estate)))
+    		if (!(c == null || c.equals(Cards.duplicate) || c.equals(Cards.estate)))
     			return c;
     	}
     	// Don't call if we can't gain a copy 

--- a/vdom/src/com/vdom/core/CardImpl.java
+++ b/vdom/src/com/vdom/core/CardImpl.java
@@ -10,7 +10,7 @@ import com.vdom.api.Card;
 import com.vdom.api.GameEvent;
 import com.vdom.core.MoveContext.TurnPhase;
 
-public class CardImpl implements Card {
+public class CardImpl implements Card, Comparable<Card>{
 	private static final long serialVersionUID = 1L;
     // Template (immutable)
     Cards.Kind kind;
@@ -692,7 +692,7 @@ public class CardImpl implements Card {
             } else {
             	context.addCoins(addGold);
             }
-            currentPlayer.addVictoryTokens(context, addVictoryTokens);
+            currentPlayer.addVictoryTokens(context, addVictoryTokens, this);
             if (providePotion()) {
                 context.potions++;
             }
@@ -909,7 +909,7 @@ public class CardImpl implements Card {
 		}
 		if (is(Type.Event, null)) {
 			context.buys += addBuys;
-			context.getPlayer().addVictoryTokens(context, addVictoryTokens);
+			context.getPlayer().addVictoryTokens(context, addVictoryTokens, this);
 		}
 		if (this.equals(Cards.estate)) {
         	Card inheritance = context.getPlayer().getInheritance();
@@ -1315,6 +1315,10 @@ public class CardImpl implements Card {
         } else {
             return this.pileCreator;
         }
+    }
+
+    public int compareTo(Card other) {
+        return getName().compareTo(other.getName());
     }
 
 }

--- a/vdom/src/com/vdom/core/CardImpl.java
+++ b/vdom/src/com/vdom/core/CardImpl.java
@@ -466,7 +466,12 @@ public class CardImpl implements Card, Comparable<Card>{
 	    	}
 	    	return false;
     	}
-    	return player.getInheritance().is(t) || this.is(t);
+
+        if (player.getInheritance().is(t)) return true;
+        for (int i = 0; i < types.length; ++i) {
+            if (types[i] == t) return true;
+        }
+        return false;
     }
 
     public int getNumberOfTypes(Player player) {
@@ -705,7 +710,6 @@ public class CardImpl implements Card, Comparable<Card>{
             	additionalCardActions(game, context, currentPlayer);
             } else {
             	// Play the inheritance virtual card
-            	this.startInheritingCardAbilities(inheritedCard.getTemplateCard().instantiate());
             	CardImpl cardToPlay = (CardImpl) this.behaveAsCard();
 		        context.freeActionInEffect++;
 		        cardToPlay.play(game, context, false);
@@ -961,7 +965,11 @@ public class CardImpl implements Card, Comparable<Card>{
     }
     
     @Override
-    public void isTrashed(MoveContext context) { }
+    public void isTrashed(MoveContext context) {
+        // card left play - stop any impersonations
+        this.getControlCard().stopImpersonatingCard();
+        this.getControlCard().stopInheritingCardAbilities();
+    }
 
     public boolean isImpersonatingAnotherCard() {
         return !(this.impersonatingCard == null);

--- a/vdom/src/com/vdom/core/CardImplAdventures.java
+++ b/vdom/src/com/vdom/core/CardImplAdventures.java
@@ -893,6 +893,13 @@ public class CardImplAdventures extends CardImpl {
                 event.card = card;
                 context.game.broadcastEvent(event);
             }
+
+            //Start inheriting estates the player already owns
+            for (Card c : context.player.getAllCards()) {
+                if (c.equals(Cards.estate)) {
+                    ((CardImpl)c).startInheritingCardAbilities(context.player.inheritance.getTemplateCard().instantiate());
+                }
+            }
         }
     }
     

--- a/vdom/src/com/vdom/core/CardImplEmpires.java
+++ b/vdom/src/com/vdom/core/CardImplEmpires.java
@@ -165,7 +165,7 @@ public class CardImplEmpires extends CardImpl {
     	
     	switch (trashKind) {
     	case CrumblingCastle:
-        	context.player.addVictoryTokens(context, 1);
+        	context.player.addVictoryTokens(context, 1, Cards.crumblingCastle);
         	context.player.gainNewCard(Cards.silver, this, context);
 			break;
         case Rocks:
@@ -326,7 +326,7 @@ public class CardImplEmpires extends CardImpl {
                 			drawDebtCost >= nextPlayerDebtCost ||
                 			drawPotionCost >= nextPlayerPotionCost)) {
         		context.addCoins(1);
-        		currentPlayer.addVictoryTokens(context, 1);
+        		currentPlayer.addVictoryTokens(context, 1, this);
         	}
         }
     }
@@ -430,7 +430,7 @@ public class CardImplEmpires extends CardImpl {
     	if (game.getPileVpTokens(c) >= 4) {
     		int numTokens = game.getPileVpTokens(c);
     		game.removePileVpTokens(c, numTokens, context);
-    		currentPlayer.addVictoryTokens(context, numTokens);
+    		currentPlayer.addVictoryTokens(context, numTokens, this);
     		currentPlayer.trash(currentPlayer.playedCards.removeLastCard(), this.getControlCard(), context);
     	} else {
     		game.addPileVpTokens(c, 1, context);
@@ -634,7 +634,7 @@ public class CardImplEmpires extends CardImpl {
         	context.addCoins(2);
         }
         if (isVictory) {
-        	currentPlayer.addVictoryTokens(context, 2);
+        	currentPlayer.addVictoryTokens(context, 2, this);
         }
     }
     
@@ -748,7 +748,7 @@ public class CardImplEmpires extends CardImpl {
     		if (Cards.estate.equals(currentPlayer.gainNewCard(Cards.estate, this.getControlCard(), context))) {
     			int numTokens = context.game.getPileVpTokens(Cards.wildHunt);
     			context.game.removePileVpTokens(Cards.wildHunt, numTokens, context);
-    			currentPlayer.addVictoryTokens(context, numTokens);
+    			currentPlayer.addVictoryTokens(context, numTokens, this);
     		}
     	}
     }
@@ -838,7 +838,7 @@ public class CardImplEmpires extends CardImpl {
     	context.player.gainNewCard(Cards.silver, this.getControlCard(), context);
     	int silversGained = context.getNumCardsGainedThisTurn(Kind.Silver);
     	if (silversGained > 0)
-    		context.player.addVictoryTokens(context, silversGained);
+    		context.player.addVictoryTokens(context, silversGained, this);
     }
     
     private void delve(MoveContext context) {
@@ -848,7 +848,7 @@ public class CardImplEmpires extends CardImpl {
     private void dominate(MoveContext context) {
     	Card gainedCard = context.player.gainNewCard(Cards.province, this.getControlCard(), context);
     	if (Cards.province.equals(gainedCard)) {
-    		context.getPlayer().controlPlayer.addVictoryTokens(context, 9);
+    		context.getPlayer().controlPlayer.addVictoryTokens(context, 9, this);
     	}
     }
     
@@ -870,7 +870,7 @@ public class CardImplEmpires extends CardImpl {
 			toTrash = hand.get(toTrash);
 			hand.remove(toTrash);
 			p.trash(toTrash, this.getControlCard(), context);
-			p.addVictoryTokens(context, trashCost);
+			p.addVictoryTokens(context, trashCost, this);
     	}
     }
     
@@ -904,7 +904,7 @@ public class CardImplEmpires extends CardImpl {
     private void triumph(MoveContext context) {
     	Card gainedCard = context.player.gainNewCard(Cards.estate, this.getControlCard(), context);
     	if (Cards.estate.equals(gainedCard)) {
-    		context.getPlayer().addVictoryTokens(context, context.getNumCardsGainedThisTurn());
+    		context.getPlayer().addVictoryTokens(context, context.getNumCardsGainedThisTurn(), this);
     	}
     }
     

--- a/vdom/src/com/vdom/core/CardImplEmpires.java
+++ b/vdom/src/com/vdom/core/CardImplEmpires.java
@@ -875,15 +875,21 @@ public class CardImplEmpires extends CardImpl {
     }
     
     private void saltTheEarth(MoveContext context) {
+		Card[] availableVictories = context.game.getCardsInGame(GetCardsInGameOptions.TopOfPiles, true, Type.Victory);
+		if (availableVictories.length == 0) {
+			return;
+		}
+
     	Card toTrash = context.getPlayer().controlPlayer.saltTheEarth_cardToTrash(context);
 		CardPile pile = context.game.getPile(toTrash);
 		if (toTrash.isPlaceholderCard()) {
 			toTrash = pile.topCard();
 		}
     	if (toTrash == null || !toTrash.is(Type.Victory) || pile.isEmpty() || !pile.topCard().equals(toTrash)) {
-    		Util.playerError(context.getPlayer(), "Salt the Earth picked invalid card, picking province");
-    		toTrash = Cards.province;
+    		Util.playerError(context.getPlayer(), "Salt the Earth picked invalid card, picking random Victory card.");
+    		toTrash = Util.randomCard(availableVictories);
     	}
+
     	context.getPlayer().trash(pile.removeCard(), this.getControlCard(), context);
     }
     

--- a/vdom/src/com/vdom/core/CardImplProsperity.java
+++ b/vdom/src/com/vdom/core/CardImplProsperity.java
@@ -111,7 +111,7 @@ public class CardImplProsperity extends CardImpl {
 
             currentPlayer.hand.remove(card);
             currentPlayer.trash(card, this.getControlCard(), context);
-            currentPlayer.addVictoryTokens(context, card.getCost(context) / 2);
+            currentPlayer.addVictoryTokens(context, card.getCost(context) / 2, this);
         }
 
         for (Player player : game.getPlayersInTurnOrder()) {

--- a/vdom/src/com/vdom/core/CardImplSeaside.java
+++ b/vdom/src/com/vdom/core/CardImplSeaside.java
@@ -117,7 +117,11 @@ public class CardImplSeaside extends CardImpl {
         for (int i = 0; i < returnCount; i++) {
             int idx = currentPlayer.hand.indexOf(card);
             if (idx > -1) {
-                pile.addCard(currentPlayer.hand.remove(idx));
+                Card returningCard = currentPlayer.hand.remove(idx);
+                if (returningCard.equals(Cards.estate) && currentPlayer.getInheritance() != null) {
+                    ((CardImpl)returningCard).stopInheritingCardAbilities();
+                }
+                pile.addCard(returningCard);
             } else {
                 Util.playerError(currentPlayer, "Ambassador return to supply error, just returning those available.");
                 break;

--- a/vdom/src/com/vdom/core/Game.java
+++ b/vdom/src/com/vdom/core/Game.java
@@ -687,7 +687,7 @@ public class Game {
     		if (tokensLeft > 0) {
     			int tokensToTake = Math.min(tokensLeft, 2);
     			removePileVpTokens(Cards.baths, tokensToTake, context);
-    			player.addVictoryTokens(context, tokensToTake);
+    			player.addVictoryTokens(context, tokensToTake, Cards.baths);
     		}
         }
         
@@ -793,7 +793,7 @@ public class Game {
     		}
     		if (highestBidder != null) {
     			MoveContext bidContext = new MoveContext(this, highestBidder);
-    			highestBidder.addVictoryTokens(bidContext, 8);
+    			highestBidder.addVictoryTokens(bidContext, 8, Cards.mountainPass);
     			highestBidder.gainDebtTokens(highestBid);
     			GameEvent event = new GameEvent(GameEvent.EventType.DebtTokensObtained, context);
             	event.setAmount(highestBid);
@@ -1346,7 +1346,7 @@ public class Game {
 		player.discard(player.getHand().remove(player.getHand().indexOf(toDiscard)), Cards.arena, context);
 		int tokensToTake = Math.min(getPileVpTokens(Cards.arena), 2);
 		removePileVpTokens(Cards.arena, tokensToTake, context);
-		player.addVictoryTokens(context, tokensToTake);
+		player.addVictoryTokens(context, tokensToTake, Cards.arena);
     }
     
     public static boolean isModifierCard(Card card) {
@@ -1995,7 +1995,7 @@ public class Game {
         }
 
         if(!buy.is(Type.Event)) {
-            player.addVictoryTokens(context, context.countGoonsInPlay());
+            player.addVictoryTokens(context, context.countGoonsInPlay(), Cards.goons);
         }
 
         if (!buy.is(Type.Event) && context.countMerchantGuildsInPlayThisTurn() > 0)
@@ -2111,7 +2111,7 @@ public class Game {
     		if (tokensLeft > 0) {
     			int tokensToTake = Math.min(tokensLeft, 2);
     			removePileVpTokens(Cards.basilica, tokensToTake, context);
-    			context.getPlayer().addVictoryTokens(context, tokensToTake);
+    			context.getPlayer().addVictoryTokens(context, tokensToTake, Cards.basilica);
     		}
     	}
     }
@@ -2125,7 +2125,7 @@ public class Game {
             		if (tokensLeft > 0) {
             			int tokensToTake = Math.min(tokensLeft, 2);
             			removePileVpTokens(Cards.colonnade, tokensToTake, context);
-            			player.addVictoryTokens(context, tokensToTake);
+            			player.addVictoryTokens(context, tokensToTake, Cards.colonnade);
             		}
 	    		}
 	    	}
@@ -2139,7 +2139,7 @@ public class Game {
 	    		int tokensLeft = getPileVpTokens(Cards.defiledShrine);
 	    		if (tokensLeft > 0) {
 	    			removePileVpTokens(Cards.defiledShrine, tokensLeft, context);
-	    			context.getPlayer().addVictoryTokens(context, tokensLeft);
+	    			context.getPlayer().addVictoryTokens(context, tokensLeft, Cards.defiledShrine);
 	    		}
 	    	}
 	    }
@@ -3241,7 +3241,7 @@ public class Game {
                     		if (tokensLeft > 0) {
                     			int tokensToTake = Math.min(tokensLeft, 2);
                     			removePileVpTokens(Cards.labyrinth, tokensToTake, context);
-                    			player.addVictoryTokens(context, tokensToTake);
+                    			player.addVictoryTokens(context, tokensToTake, Cards.labyrinth);
                     		}
                     	}
                     }
@@ -3394,18 +3394,18 @@ public class Game {
                     		if (tokensLeft > 0) {
                     			int tokensToTake = Math.min(tokensLeft, 2);
                     			removePileVpTokens(Cards.battlefield, tokensToTake, context);
-                    			player.addVictoryTokens(context, tokensToTake);
+                    			player.addVictoryTokens(context, tokensToTake, Cards.battlefield);
                     		}
                     	}
                     	if (cardInGame(Cards.aqueduct)) {
                     		int tokensLeft = getPileVpTokens(Cards.aqueduct);
                     		if (tokensLeft > 0) {
                     			removePileVpTokens(Cards.aqueduct, tokensLeft, context);
-                    			player.addVictoryTokens(context, tokensLeft);
+                    			player.addVictoryTokens(context, tokensLeft, Cards.aqueduct);
                     		}
                     	}
                     	int groundsKeepers = context.countCardsInPlay(Cards.groundskeeper);
-                    	player.addVictoryTokens(context, groundsKeepers);
+                    	player.addVictoryTokens(context, groundsKeepers, Cards.groundskeeper);
                     }
                     
                     if (gainedCardAbility.equals(Cards.illGottenGains)) {
@@ -3536,7 +3536,7 @@ public class Game {
                         }
                     } else if (gainedCardAbility.equals(Cards.emporium)) {
                     	if (context.countActionCardsInPlay() >= 5) {
-                    		player.addVictoryTokens(context, 2);
+                    		player.addVictoryTokens(context, 2, Cards.emporium);
                     	}
                     } else if (gainedCardAbility.equals(Cards.fortune)) {
                     	int gladiators = context.countCardsInPlayByName(Cards.gladiator);
@@ -3546,7 +3546,7 @@ public class Game {
                     } else if (gainedCardAbility.equals(Cards.rocks)) {
                     	player.gainNewCard(Cards.silver, event.card, context);
                     } else if (gainedCardAbility.equals(Cards.crumblingCastle)) {
-                    	player.addVictoryTokens(context, 1);
+                    	player.addVictoryTokens(context, 1, Cards.crumblingCastle);
                     	player.gainNewCard(Cards.silver, event.card, context);
                     } else if (gainedCardAbility.equals(Cards.hauntedCastle) && context.game.getCurrentPlayer() == player) {
                     	player.gainNewCard(Cards.gold, event.card, context);
@@ -3586,7 +3586,7 @@ public class Game {
                     } else if (gainedCardAbility.equals(Cards.temple)) {
                     	int numTokens = context.game.getPileVpTokens(Cards.temple);
                     	context.game.removePileVpTokens(Cards.temple, numTokens, context);
-                    	player.addVictoryTokens(context, numTokens);
+                    	player.addVictoryTokens(context, numTokens, Cards.temple);
                     } else if (gainedCardAbility.equals(Cards.sprawlingCastle)) {
                     	int duchyCount = context.game.getPile(Cards.duchy).getCount();
                         int estateCount = context.game.getPile(Cards.estate).getCount();
@@ -3627,7 +3627,7 @@ public class Game {
 
                         victoryCards += context.countVictoryCardsInPlay();
 
-                        player.addVictoryTokens(context, victoryCards);
+                        player.addVictoryTokens(context, victoryCards, Cards.grandCastle);
                     }
                     
                     if(event.card.is(Type.Action, player)) {

--- a/vdom/src/com/vdom/core/Game.java
+++ b/vdom/src/com/vdom/core/Game.java
@@ -896,6 +896,8 @@ public class Game {
                     GameEvent statusEvent = new GameEvent(GameEvent.EventType.Status, (MoveContext) context);
                     broadcastEvent(statusEvent);
 
+
+
                     playBuy(context, buy);
                     playerPayOffDebt(player, context);
                     if (context.returnToActionPhase)
@@ -1155,10 +1157,6 @@ public class Game {
                     player.playedByPrince.add(card2);
                 }
                 player.prince.remove(card2);
-                if (card2.equals(Cards.estate) && player.getInheritance() != null) {
-                    ((CardImpl)card2).startInheritingCardAbilities(player.getInheritance().getTemplateCard().instantiate());
-
-                }
                 
                 context.freeActionInEffect++;
                 try {
@@ -3171,9 +3169,16 @@ public class Game {
                         return;
                     }
 
+                    //Start inheriting newly gained estate
+                    if (event.card.equals(Cards.estate) && event.player.getInheritance() != null) {
+                        ((CardImpl)event.card).startInheritingCardAbilities(player.getInheritance().getTemplateCard().instantiate());
+                    }
+
                     if (context != null && event.card.is(Type.Victory)) {
                         context.vpsGainedThisTurn += event.card.getVictoryPoints();
                     }
+
+
                     
                     if (Cards.inn.equals(event.responsible))
                         Util.debug((String.format("discard pile: %d", player.discard.size())), true);

--- a/vdom/src/com/vdom/core/RemotePlayer.java
+++ b/vdom/src/com/vdom/core/RemotePlayer.java
@@ -706,6 +706,7 @@ public class RemotePlayer extends IndirectPlayer implements GameEventListener, E
             extras.add(curPlayer.getPlayerName());
             extras.add(counts);
             extras.add(curPlayer.getVictoryPointTotals(counts));
+            extras.add(curPlayer.getVictoryTokensTotals());
             long duration = System.currentTimeMillis() - whenStarted;
             extras.add(duration);
             if (!event.getContext().cardsSpecifiedOnStartup()) {

--- a/vdom/src/com/vdom/core/Util.java
+++ b/vdom/src/com/vdom/core/Util.java
@@ -360,9 +360,6 @@ public class Util {
         for (Card card : player.hand) {
             if (card.equals(reactionCard)) {
                 horseTraders = card;
-                if (reactionCard.equals(Cards.estate)) {
-                	((CardImpl)card).startInheritingCardAbilities(Cards.horseTraders.getTemplateCard().instantiate());
-                }
             }
         }
 


### PR DESCRIPTION
I closed the previous pull request as it was on the wrong branch.

Added a rundown of which card contributed what amount of victory tokens in each players game summary. Same as the Castle details.
Added an option to enable or disable this behavior (also for Castles).

![vp_tokens](https://cloud.githubusercontent.com/assets/496185/20003591/a3a2ecd8-a287-11e6-9afb-fe88aecbb193.png)

Edit:
Also fixes #411, #412, #413 and #415