### PR TITLE
Fixes #554 : Raider doesn't attack all players

### DIFF
--- a/vdom/src/com/vdom/core/CardImplNocturne.java
+++ b/vdom/src/com/vdom/core/CardImplNocturne.java
@@ -1093,12 +1093,12 @@ public class CardImplNocturne extends CardImpl {
             	for (Card card : player.hand){
             		player.reveal(card, getControlCard(), playerContext);
             	}
-            	return;
+            	continue;
             }
             if (discardCards.size() == 1) {
             	int idx = player.hand.indexOf(discardCards.get(0));
         		player.discard(player.hand.remove(idx), this.getControlCard(), context);
-            	return;
+            	continue;
             }
             Card toDiscard = player.controlPlayer.raider_cardToDiscard(playerContext, discardCards.toArray(new Card[0]));
             if (toDiscard == null || !discardCards.contains(toDiscard)) {


### PR DESCRIPTION
In the loop that attacks all pkayers, there is two return lines for a player with 0 or 1 card to discard.

Do, it exits the method and following players aren't attacked.