### PR TITLE
Fix crashes

### DIFF
--- a/vdom/src/com/vdom/core/CardImplBase.java
+++ b/vdom/src/com/vdom/core/CardImplBase.java
@@ -385,7 +385,7 @@ public class CardImplBase extends CardImpl {
     
     private void mine(MoveContext context, Player currentPlayer) {
         Card cardToUpgrade = currentPlayer.controlPlayer.mine_treasureFromHandToUpgrade(context);
-        if ((Game.errataMineForced && cardToUpgrade == null) || !cardToUpgrade.is(Type.Treasure, currentPlayer, context)) {
+        if ((Game.errataMineForced && cardToUpgrade == null) || (cardToUpgrade != null && !cardToUpgrade.is(Type.Treasure, currentPlayer, context))) {
             Card[] cards = currentPlayer.getTreasuresInHand(context).toArray(new Card[] {});
             if (cards.length != 0) {
                 Util.playerError(currentPlayer, "Mine card to upgrade was invalid, picking treasure from hand.");

--- a/vdom/src/com/vdom/core/Player.java
+++ b/vdom/src/com/vdom/core/Player.java
@@ -1497,7 +1497,12 @@ public abstract class Player {
     }
 
     protected void discardRemainingCardsFromHand(MoveContext context, Card[] cardsToKeep, Card responsibleCard, int keepCardCount) {
-        ArrayList<Card> keepCards = new ArrayList<Card>(Arrays.asList(cardsToKeep));
+        ArrayList<Card> keepCards;
+        if (cardsToKeep == null) {
+            keepCards = new ArrayList<Card>();
+        } else {
+            keepCards = new ArrayList<Card>(Arrays.asList(cardsToKeep));
+        }
 
         if (keepCardCount > 0) {
             boolean bad = false;


### PR DESCRIPTION
This PR concern issue #607.
- Fix #619 crash on Mine when playing with errata and when there is no treasure card in hand.
- Fix crash when discarding all cards from hands except the ones to keep (legionary)