### PR TITLE
Fix color issue

### DIFF
--- a/androminion/res/values/card_styles.xml
+++ b/androminion/res/values/card_styles.xml
@@ -3,10 +3,10 @@
 
     <!-- Custom CardView attributes. -->
     <attr name="cardBackgroundColor" type="reference|color" />
+    <attr name="cardCountColor" type="reference|color" />
     <attr name="cardNameBackgroundColor" type="reference|color" />
     <attr name="cardTextColor" type="reference|color" />
-    <attr name="cardCountColor" type="reference|color" />
-
+    
     <style name="CardView">
         <item name="cardBackgroundColor">@color/cardDefaultBackgroundColor</item>
         <item name="cardNameBackgroundColor">@color/cardDefaultTextBackgroundColor</item>

--- a/androminion/src/com/mehtank/androminion/ui/CardView.java
+++ b/androminion/src/com/mehtank/androminion/ui/CardView.java
@@ -232,16 +232,19 @@ public class CardView extends FrameLayout implements OnLongClickListener, Checka
 		}
 
 		int cardStyleId = getStyleForCard(c);
+        
+        // According to the documentation, attributes should be ordered by their values
+        // To be sure of it, order them by name in the resouce file and here
 		TypedArray cardStyle = getContext().obtainStyledAttributes(cardStyleId,
 				new int[] {
-					R.attr.cardBackgroundColor,
+                    R.attr.cardBackgroundColor,
+                    R.attr.cardCountColor,
 					R.attr.cardNameBackgroundColor,
-					R.attr.cardTextColor,
-					R.attr.cardCountColor });
+					R.attr.cardTextColor });
 		int bgColor = cardStyle.getColor(0, R.color.cardDefaultBackgroundColor);
-		int textColor = cardStyle.getColor(2, R.color.cardDefaultTextColor);
-        int nameBgColor = cardStyle.getColor(1, R.color.cardDefaultTextBackgroundColor);
-		int countColor = cardStyle.getColor(3, R.color.cardDefaultTextColor);
+		int textColor = cardStyle.getColor(3, R.color.cardDefaultTextColor);
+        int nameBgColor = cardStyle.getColor(2, R.color.cardDefaultTextBackgroundColor);
+		int countColor = cardStyle.getColor(1, R.color.cardDefaultTextColor);
 		cardStyle.recycle();
 		
 		cardBox.setBackgroundColor(bgColor);


### PR DESCRIPTION
In the method obtainStyledAttributes, attributes must be ordered by their values.

In this repository it works well because values are set by the attributes order of appearance.

In a repository I've made to build Androminion with Adroid Studio, values are set by  the attrubute names order.